### PR TITLE
add Vagrant config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vagrant

--- a/README.md
+++ b/README.md
@@ -64,3 +64,7 @@ handler - mod_perl handlers
 ##guidepost api:
 
 see editor_help.html
+
+##Development
+
+Te get development environment, just execute `vagrant up frontend` in git root. And `vagrant ssh frontend` gives you command line of that virtual machine.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,66 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure(2) do |config|
+
+  ###  FRONTEND  ###################################################
+  config.vm.define "frontend" do |frontend|
+    frontend.vm.box = "fedora/23-cloud-base"
+
+    frontend.vm.network "forwarded_port", guest: 80, host: 5000
+
+    frontend.vm.synced_folder ".", "/vagrant", type: "rsync", rsync__exclude: ".git/"
+
+    frontend.vm.network "private_network", ip: "192.168.242.51"
+
+    # Update the system
+    #frontend.vm.provision "shell",
+    #  inline: "sudo dnf -y update"
+
+    # Install package
+    frontend.vm.provision "shell",
+      inline: "sudo dnf -y install httpd mod_perl sqlite perl-JSON perl-DBI perl-Data-Dumper perl-DBD-SQLite perl-Image-ExifTool perl-App-cpanminus perl-Exporter-Tiny perl-Class-Load perl-Test-Warn perl-Capture-Tiny perl-Sub-Uplevel perl-Moo perl-Package-Stash perl-Devel-StackTrace perl-Test-Most perl-Type-Tiny perl-HTML-Parser perl-HTML-Tagset perl-Socket6 perl-Sys-Syslog perl-libwww-perl"
+
+
+    # Install unpackaged perl modules
+    frontend.vm.provision "shell", inline: <<-EOF
+      (echo y;echo o conf prerequisites_policy follow;echo o conf commit)|sudo cpan
+      sudo cpanm install 'Geo::JSON'
+      sudo cpanm install 'HTML::Entities'
+      sudo cpanm install 'Net::Subnet'
+    EOF
+
+    # Create directory structure
+    frontend.vm.provision "shell", inline: <<-EOF
+      sudo mkdir -p /var/www/mapy/ && sudo chown vagrant /var/www/mapy/
+      sudo mkdir -p /var/www/zapi && sudo chown vagrant /var/www/zapi
+      ls -d /var/www/zapi/handler || sudo ln -s /vagrant/handler /var/www/zapi/
+    EOF
+
+    # create db
+    frontend.vm.provision "shell",
+      inline: "ls /vagrant/sqlite-create-schema.sql || sqlite3 /var/www/mapy/guidepost < /vagrant/sqlite-create-schema.sql"
+    # TODO what about /var/www/mapy/commons ?
+    
+
+    # copy apache config
+    frontend.vm.provision "shell", run: "always",
+      inline: "sudo cp /vagrant/httpd-api.conf /etc/httpd/conf.d/"
+
+    # Disable selinux
+    frontend.vm.provision "shell",
+      inline: "sudo setenforce 0"
+
+    # start apache
+    frontend.vm.provision "shell", run: "always",
+      inline: "service httpd start"
+
+    frontend.vm.provision "shell", run: "always", inline: <<-EOF
+      echo "#########################################################"
+      echo "###   Your development instance of OSMCZ API          ###"
+      echo "###   is now running at: http://localhost:5000        ###"
+      echo "#########################################################"
+    EOF
+  end
+
+end

--- a/httpd-api.conf
+++ b/httpd-api.conf
@@ -1,0 +1,21 @@
+<DirectoryMatch "^/.*/\.git/">
+    Order deny,allow
+    Deny from all
+</DirectoryMatch>
+
+Header set Access-Control-Allow-Origin "*"
+PerlRequire /var/www/zapi/handler/startup.pl
+PerlSetVar ReloadAll Off
+
+<Location /table>
+  SetHandler perl-script
+  PerlResponseHandler Guidepost::Table
+  PerlOptions +ParseHeaders
+</Location>
+
+<Location /commons>
+  SetHandler perl-script
+  PerlResponseHandler Guidepost::Commons
+  PerlOptions +ParseHeaders
+</Location>
+

--- a/sqlite-create-schema.sql
+++ b/sqlite-create-schema.sql
@@ -1,0 +1,25 @@
+CREATE TABLE changes (
+  id integer primary key AUTOINCREMENT,
+  gp_id integer,
+  col varchar,
+  value varchar,
+  action varchar
+);
+
+CREATE TABLE guidepost (
+  id integer primary key AUTOINCREMENT,
+  lat numeric,
+  lon numeric,
+  url varchar,
+  name varchar,
+  attribution varchar,
+  ref varchar,
+  note varchar
+);
+
+create table tags (
+  id integer primary key AUTOINCREMENT,
+  gp_id integer,
+  k varchar,
+  v varchar
+);


### PR DESCRIPTION
Tohle prida config pro Vagrant, takze aby clovek ziskal vyvojove prostredi tak staci:
  vagrant up frontend
a pak na localhost:5000 bude dostupny apache z te virtualky.
Do virtualky se lze dostate
  vagrant ssh frontend
Virtualku shodite
  vagrant halt frontend
pripadne rovnout smazat z disku
  vagrant destroy frontend

Problem je ze kod pouziva asi jeste stare API, protoze momentalne dostavam:
`[Tue Apr 19 10:59:59.063821 2016] [perl:error] [pid 2461] [client 192.168.121.46:60624] Can't locate object method "remote_ip" via package "Apache2::Connection" at /var/www/zapi/handler/Guidepost/Table.pm line 307.\n`
Coz dle
  http://httpd.apache.org/docs/2.4/developer/new_api_2_4.html
bylo zmeneno z remote_ip na client_ip.
